### PR TITLE
Add ExpectSetArgs method

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -830,9 +830,9 @@ var _ = Describe("RedisMock", func() {
 
 		It("SetArgs", func() {
 			operationStatusCmd(clientMock, func() *ExpectedStatus {
-				return clientMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+				return clientMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute, Get: true})
 			}, func() *redis.StatusCmd {
-				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute, Get: true})
 			})
 		})
 

--- a/client_test.go
+++ b/client_test.go
@@ -828,6 +828,14 @@ var _ = Describe("RedisMock", func() {
 			})
 		})
 
+		It("SetArgs", func() {
+			operationStatusCmd(clientMock, func() *ExpectedStatus {
+				return clientMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+			}, func() *redis.StatusCmd {
+				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+			})
+		})
+
 		It("StrLen", func() {
 			operationIntCmd(clientMock, func() *ExpectedInt {
 				return clientMock.ExpectStrLen("key")

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -829,9 +829,9 @@ var _ = Describe("RedisMock", func() {
 
 		It("SetArgs", func() {
 			operationStatusCmd(clusterMock, func() *ExpectedStatus {
-				return clusterMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+				return clusterMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute, Get: true})
 			}, func() *redis.StatusCmd {
-				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute, Get: true})
 			})
 		})
 

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -827,6 +827,14 @@ var _ = Describe("RedisMock", func() {
 			})
 		})
 
+		It("SetArgs", func() {
+			operationStatusCmd(clusterMock, func() *ExpectedStatus {
+				return clusterMock.ExpectSetArgs("key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+			}, func() *redis.StatusCmd {
+				return client.SetArgs(ctx, "key", "value", redis.SetArgs{TTL: 1 * time.Minute})
+			})
+		})
+
 		It("StrLen", func() {
 			operationIntCmd(clusterMock, func() *ExpectedInt {
 				return clusterMock.ExpectStrLen("key")

--- a/expect.go
+++ b/expect.go
@@ -76,6 +76,7 @@ type baseMock interface {
 	ExpectSetNX(key string, value interface{}, expiration time.Duration) *ExpectedBool
 	ExpectSetXX(key string, value interface{}, expiration time.Duration) *ExpectedBool
 	ExpectSetRange(key string, offset int64, value string) *ExpectedInt
+	ExpectSetArgs(key string, value string, args redis.SetArgs) *ExpectedStatus
 	ExpectStrLen(key string) *ExpectedInt
 
 	ExpectGetBit(key string, offset int64) *ExpectedInt

--- a/mock.go
+++ b/mock.go
@@ -751,6 +751,13 @@ func (m *mock) ExpectSetRange(key string, offset int64, value string) *ExpectedI
 	return e
 }
 
+func (m *mock) ExpectSetArgs(key string, value string, args redis.SetArgs) *ExpectedStatus {
+	e := &ExpectedStatus{}
+	e.cmd = m.factory.SetArgs(m.ctx, key, value, args)
+	m.pushExpect(e)
+	return e
+}
+
 func (m *mock) ExpectStrLen(key string) *ExpectedInt {
 	e := &ExpectedInt{}
 	e.cmd = m.factory.StrLen(m.ctx, key)


### PR DESCRIPTION
Need this for a test using SetArgs instead of two operations GET and SET
GETSET is deprecated and shouldn't be used. Also doesn't support TTL